### PR TITLE
Add image build and publish workflow in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Build and Push Docker Images to GitHub Packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+            - x86_64-unknown-linux-musl
+            - aarch64-unknown-linux-musl
+            - armv7-unknown-linux-musleabihf
+            - i686-unknown-linux-musl
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push ${{ matrix.target }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/rust-musl-cross:${{ matrix.target }}
+          build-args: |
+            TARGET=${{ matrix.target }}
+            RUST_MUSL_MAKE_CONFIG=config.mak


### PR DESCRIPTION
e.g. https://github.com/zanieb/rust-musl-cross-pyspy/actions/runs/11279531355 / https://github.com/zanieb/rust-musl-cross-pyspy/pkgs/container/rust-musl-cross

This solves a few problems

1. In the future, we can test builds during changes here
2. Builds are performed and published automatically instead of manually
3. The container registry is self-contained, does not require a DockerHub account